### PR TITLE
Adds labeled tunnels and plumbs config values. Allows ngrok auth_token from env var.

### DIFF
--- a/labeled.go
+++ b/labeled.go
@@ -18,6 +18,8 @@ type Labeled struct {
 	ctx context.Context
 
 	opts   []config.LabeledTunnelOption
+
+	// A map of label, value pairs for this tunnel.
 	Labels map[string]string `json:"labels,omitempty"`
 
 	l *zap.Logger
@@ -61,19 +63,17 @@ func (t *Labeled) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			case "labels":
 				for nesting := d.Nesting(); d.NextBlock(nesting); {
 					directive := d.Val()
+					if directive == "}" || directive == "{" {
+						continue
+					}
 					args := d.RemainingArgs()
-					switch directive {
-					case "label":
-						if len(args) != 2 {
-							return d.ArgErr()
-						}
-						if t.Labels == nil {
-							t.Labels = map[string]string{}
-						}
-						t.Labels[args[0]] = args[1]
-					default:
+					if len(args) != 1 {
 						return d.ArgErr()
 					}
+					if t.Labels == nil {
+						t.Labels = map[string]string{}
+					}
+					t.Labels[directive] = args[0]
 				}
 			default:
 				return d.ArgErr()

--- a/labeled.go
+++ b/labeled.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
-	"golang.ngrok.com/ngrok/config"
 	"go.uber.org/zap"
+	"golang.ngrok.com/ngrok/config"
 )
 
 func init() {
@@ -17,7 +17,7 @@ func init() {
 type Labeled struct {
 	ctx context.Context
 
-	opts []config.LabeledTunnelOption
+	opts   []config.LabeledTunnelOption
 	Labels map[string]string `json:"labels,omitempty"`
 
 	l *zap.Logger
@@ -37,7 +37,7 @@ func (*Labeled) CaddyModule() caddy.ModuleInfo {
 func (lt *Labeled) Provision(ctx caddy.Context) error {
 	lt.ctx = ctx
 	lt.l = ctx.Logger()
-	
+
 	for label, value := range lt.Labels {
 		lt.opts = append(lt.opts, config.WithLabel(label, value))
 		lt.l.Info("applying label", zap.String("label", label), zap.String("value", value))
@@ -58,25 +58,25 @@ func (t *Labeled) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		}
 		for d.NextBlock(0) {
 			switch d.Val() {
-				case "labels":
-					for nesting := d.Nesting(); d.NextBlock(nesting); {
-						directive := d.Val()
-						args := d.RemainingArgs()
-						switch directive {
-							case "label":
-								if len(args) != 2 {
-									return d.ArgErr()
-								}
-								if t.Labels == nil {
-									t.Labels = map[string]string{}
-								}
-								t.Labels[args[0]] = args[1]
-							default:
-								return d.ArgErr()
+			case "labels":
+				for nesting := d.Nesting(); d.NextBlock(nesting); {
+					directive := d.Val()
+					args := d.RemainingArgs()
+					switch directive {
+					case "label":
+						if len(args) != 2 {
+							return d.ArgErr()
 						}
+						if t.Labels == nil {
+							t.Labels = map[string]string{}
+						}
+						t.Labels[args[0]] = args[1]
+					default:
+						return d.ArgErr()
 					}
-				default:
-					return d.ArgErr()
+				}
+			default:
+				return d.ArgErr()
 
 			}
 		}

--- a/labeled.go
+++ b/labeled.go
@@ -1,0 +1,92 @@
+package ngroklistener
+
+import (
+	"context"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"golang.ngrok.com/ngrok/config"
+	"go.uber.org/zap"
+)
+
+func init() {
+	caddy.RegisterModule(new(Labeled))
+}
+
+// ngrok Labeled Tunnel
+type Labeled struct {
+	ctx context.Context
+
+	opts []config.LabeledTunnelOption
+	Labels map[string]string `json:"labels,omitempty"`
+
+	l *zap.Logger
+}
+
+// CaddyModule implements caddy.Module
+func (*Labeled) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "caddy.listeners.ngrok.tunnels.labeled",
+		New: func() caddy.Module {
+			return new(Labeled)
+		},
+	}
+}
+
+// Provision implements caddy.Provisioner
+func (lt *Labeled) Provision(ctx caddy.Context) error {
+	lt.ctx = ctx
+	lt.l = ctx.Logger()
+	
+	for label, value := range lt.Labels {
+		lt.opts = append(lt.opts, config.WithLabel(label, value))
+		lt.l.Info("applying label", zap.String("label", label), zap.String("value", value))
+	}
+
+	return nil
+}
+
+// convert to ngrok's Tunnel type
+func (lt *Labeled) NgrokTunnel() config.Tunnel {
+	return config.LabeledTunnel(lt.opts...)
+}
+
+func (t *Labeled) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		if d.NextArg() {
+			return d.ArgErr()
+		}
+		for d.NextBlock(0) {
+			switch d.Val() {
+				case "labels":
+					for nesting := d.Nesting(); d.NextBlock(nesting); {
+						directive := d.Val()
+						args := d.RemainingArgs()
+						switch directive {
+							case "label":
+								if len(args) != 2 {
+									return d.ArgErr()
+								}
+								if t.Labels == nil {
+									t.Labels = map[string]string{}
+								}
+								t.Labels[args[0]] = args[1]
+							default:
+								return d.ArgErr()
+						}
+					}
+				default:
+					return d.ArgErr()
+
+			}
+		}
+	}
+	return nil
+}
+
+var (
+	_ caddy.Module          = (*Labeled)(nil)
+	_ Tunnel                = (*Labeled)(nil)
+	_ caddy.Provisioner     = (*Labeled)(nil)
+	_ caddyfile.Unmarshaler = (*Labeled)(nil)
+)

--- a/ngrok.go
+++ b/ngrok.go
@@ -28,7 +28,7 @@ type Ngrok struct {
 	ctx context.Context
 
 	// The user's ngrok authentication token
-	AuthToken string `json:"auth_token,omitempty"`
+	AuthToken string `json:"authtoken,omitempty"`
 
 	// The ngrok tunnel type and configuration; defaults to 'tcp'
 	TunnelRaw json.RawMessage `json:"tunnel,omitempty" caddy:"namespace=caddy.listeners.ngrok.tunnels inline_key=tunnel"`
@@ -77,15 +77,15 @@ func (*Ngrok) CaddyModule() caddy.ModuleInfo {
 
 // WrapListener return an ngrok listener instead the listener passed by Caddy
 func (n *Ngrok) WrapListener(net.Listener) net.Listener {
-	auth_token_option := ngrok.WithAuthtoken(n.AuthToken)
+	authtoken_option := ngrok.WithAuthtoken(n.AuthToken)
 	if n.AuthToken == "" {
-		auth_token_option = ngrok.WithAuthtokenFromEnv()
+		authtoken_option = ngrok.WithAuthtokenFromEnv()
 	}
 
 	ln, err := ngrok.Listen(
 		n.ctx,
 		n.tunnel.NgrokTunnel(),
-		auth_token_option,
+		authtoken_option,
 		ngrok.WithLogger(ngrok_zap.NewLogger(n.l)),
 	)
 	if err != nil {
@@ -104,12 +104,12 @@ func (n *Ngrok) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		for d.NextBlock(0) {
 			subdirective := d.Val()
 			switch subdirective {
-			case "auth_token":
-				var auth_token string
-				if !d.Args(&auth_token) {
-					auth_token = ""
+			case "authtoken":
+				var authtoken string
+				if !d.Args(&authtoken) {
+					authtoken = ""
 				}
-				n.AuthToken = auth_token
+				n.AuthToken = authtoken
 			case "tunnel":
 				var tunnelName string
 				if !d.Args(&tunnelName) {

--- a/ngrok.go
+++ b/ngrok.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 	"golang.ngrok.com/ngrok"
 	"golang.ngrok.com/ngrok/config"
+	ngrok_zap "golang.ngrok.com/ngrok/log/zap"
 )
 
 func init() {
@@ -85,6 +86,7 @@ func (n *Ngrok) WrapListener(net.Listener) net.Listener {
 		n.ctx,
 		n.tunnel.NgrokTunnel(),
 		auth_token_option,
+		ngrok.WithLogger(ngrok_zap.NewLogger(n.l)),
 	)
 	if err != nil {
 		panic(err)

--- a/ngrok.go
+++ b/ngrok.go
@@ -50,7 +50,7 @@ func (n *Ngrok) Provision(ctx caddy.Context) error {
 		return fmt.Errorf("loading ngrok tunnel module: %v", err)
 	}
 	n.tunnel = tmod.(Tunnel)
-	
+
 	if repl, ok := ctx.Value(caddy.ReplacerCtxKey).(*caddy.Replacer); ok {
 		n.AuthToken = repl.ReplaceKnown(n.AuthToken, "")
 	}

--- a/tcp.go
+++ b/tcp.go
@@ -45,9 +45,14 @@ func (t *TCP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			return d.ArgErr()
 		}
 		for d.NextBlock(0) {
-			switch d.Val() {
+			subdirective := d.Val()
+			switch subdirective {
 			case "address":
-				t.Address = d.Val()
+				var address string
+				if !d.Args(&address) {
+					d.ArgErr()
+				}
+				t.Address = address
 			default:
 				return d.ArgErr()
 			}

--- a/tcp.go
+++ b/tcp.go
@@ -12,15 +12,15 @@ func init() {
 
 // ngrok TCP tunnel
 type TCP struct {
-	// The TCP address to request for this edge
-	Address string `json:"address,omitempty"`
+	// The remote TCP address to request for this edge
+	RemoteAddr string `json:"remote_address,omitempty"`
 
 	opts []config.TCPEndpointOption
 }
 
 // Provision implements caddy.Provisioner
 func (t *TCP) Provision(caddy.Context) error {
-	t.opts = append(t.opts, config.WithRemoteAddr(t.Address))
+	t.opts = append(t.opts, config.WithRemoteAddr(t.RemoteAddr))
 	return nil
 }
 
@@ -47,12 +47,12 @@ func (t *TCP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		for d.NextBlock(0) {
 			subdirective := d.Val()
 			switch subdirective {
-			case "address":
-				var address string
-				if !d.Args(&address) {
+			case "remote_address":
+				var remote_address string
+				if !d.Args(&remote_address) {
 					d.ArgErr()
 				}
-				t.Address = address
+				t.RemoteAddr = remote_address
 			default:
 				return d.ArgErr()
 			}


### PR DESCRIPTION
# Why

Users often set their auth_token from env vars. This change allows that.
ngrok also offers labeled tunnels. I use them personally so I added them!
ngrok-go uses caddy logger.