### PR TITLE
Add Labeled tunnels

### DIFF
--- a/labeled.go
+++ b/labeled.go
@@ -1,0 +1,167 @@
+package ngroklistener
+
+import (
+	"fmt"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"go.uber.org/zap"
+	"golang.ngrok.com/ngrok/config"
+)
+
+func init() {
+	caddy.RegisterModule(new(Labeled))
+}
+
+// ngrok Labeled Tunnel
+type Labeled struct {
+	opts []config.LabeledTunnelOption
+
+	// A map of label, value pairs for this tunnel.
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// opaque metadata string for this tunnel.
+	Metadata string `json:"metadata,omitempty"`
+
+	l *zap.Logger
+}
+
+// CaddyModule implements caddy.Module
+func (*Labeled) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "caddy.listeners.ngrok.tunnels.labeled",
+		New: func() caddy.Module {
+			return new(Labeled)
+		},
+	}
+}
+
+// Provision implements caddy.Provisioner
+func (t *Labeled) Provision(ctx caddy.Context) error {
+	t.l = ctx.Logger()
+
+	if err := t.doReplace(); err != nil {
+		return fmt.Errorf("loading doing replacements: %v", err)
+	}
+
+	if err := t.provisionOpts(); err != nil {
+		return fmt.Errorf("provisioning labeled tunnel opts: %v", err)
+	}
+
+	return nil
+}
+
+func (t *Labeled) provisionOpts() error {
+	for label, value := range t.Labels {
+		t.opts = append(t.opts, config.WithLabel(label, value))
+		t.l.Info("applying label", zap.String("label", label), zap.String("value", value))
+	}
+
+	if t.Metadata != "" {
+		t.opts = append(t.opts, config.WithMetadata(t.Metadata))
+	}
+
+	return nil
+}
+
+func (t *Labeled) doReplace() error {
+	repl := caddy.NewReplacer()
+	replaceableFields := []*string{
+		&t.Metadata,
+	}
+
+	for _, field := range replaceableFields {
+		actual, err := repl.ReplaceOrErr(*field, false, true)
+		if err != nil {
+			return fmt.Errorf("error replacing fields: %v", err)
+		}
+
+		*field = actual
+	}
+
+	// TODO: Labels need to be replaceable
+	return nil
+}
+
+// Validate implements caddy.Validator.
+func (t *Labeled) Validate() error {
+	if t.Labels == nil || len(t.Labels) == 0 {
+		return fmt.Errorf("a label is required for labeled tunnels")
+	}
+
+	return nil
+}
+
+// convert to ngrok's Tunnel type
+func (t *Labeled) NgrokTunnel() config.Tunnel {
+	return config.LabeledTunnel(t.opts...)
+}
+
+func (t *Labeled) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		if d.NextArg() {
+			return d.ArgErr()
+		}
+
+		for nesting := d.Nesting(); d.NextBlock(nesting); {
+			subdirective := d.Val()
+			switch subdirective {
+			case "metadata":
+				if !d.AllArgs(&t.Metadata) {
+					return d.ArgErr()
+				}
+			case "label":
+				if err := t.unmarshalLabels(d); err != nil {
+					return err
+				}
+			default:
+				return d.ArgErr()
+			}
+		}
+	}
+
+	return nil
+}
+
+func (t *Labeled) unmarshalLabels(d *caddyfile.Dispenser) error {
+	var (
+		label      string
+		labelValue string
+	)
+
+	if t.Labels == nil {
+		t.Labels = map[string]string{}
+	}
+
+	label = d.Val()
+
+	if d.CountRemainingArgs() != 0 { // label is defined inline
+		if !d.AllArgs(&label, &labelValue) {
+			return d.ArgErr()
+		}
+
+		t.Labels[label] = labelValue
+
+		return nil
+	}
+
+	for nesting := d.Nesting(); d.NextBlock(nesting); { // block of labels
+		label := d.Val()
+
+		if !d.AllArgs(&labelValue) {
+			return d.ArgErr()
+		}
+
+		t.Labels[label] = labelValue
+	}
+
+	return nil
+}
+
+var (
+	_ caddy.Module          = (*Labeled)(nil)
+	_ Tunnel                = (*Labeled)(nil)
+	_ caddy.Provisioner     = (*Labeled)(nil)
+	_ caddy.Validator       = (*Labeled)(nil)
+	_ caddyfile.Unmarshaler = (*Labeled)(nil)
+)

--- a/labeled.go
+++ b/labeled.go
@@ -71,15 +71,21 @@ func (t *Labeled) doReplace() error {
 	}
 
 	for _, field := range replaceableFields {
-		actual, err := repl.ReplaceOrErr(*field, false, true)
-		if err != nil {
-			return fmt.Errorf("error replacing fields: %v", err)
-		}
-
+		actual := repl.ReplaceKnown(*field, "")
 		*field = actual
 	}
 
-	// TODO: Labels need to be replaceable
+	replacedLabels := make(map[string]string)
+
+	for labelName, labelValue := range t.Labels {
+		actualLabelName := repl.ReplaceKnown(labelName, "")
+		actualLabelValue := repl.ReplaceKnown(labelValue, "")
+
+		replacedLabels[actualLabelName] = actualLabelValue
+	}
+
+	t.Labels = replacedLabels
+
 	return nil
 }
 

--- a/labeled_test.go
+++ b/labeled_test.go
@@ -1,0 +1,75 @@
+package ngroklistener
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+)
+
+func TestParseLabeled(t *testing.T) {
+	tests := []struct {
+		input     string
+		shouldErr bool
+		expected  Labeled
+	}{
+		{`labeled {
+			metadata test
+		}`, false, Labeled{Metadata: "test"}},
+		{`labeled {
+			metadata test
+			label test me
+		}`, false, Labeled{Metadata: "test", Labels: map[string]string{"test": "me"}}},
+		{`labeled {
+			metadata test
+			label test me
+			label test2 metoo
+		}`, false, Labeled{Metadata: "test", Labels: map[string]string{"test": "me", "test2": "metoo"}}},
+		{`labeled {
+			metadata test
+			label {
+				blocks aswell
+			}
+		}`, false, Labeled{Metadata: "test", Labels: map[string]string{"blocks": "aswell"}}},
+		{`labeled {
+			metadata test
+			label {
+				test me
+				test2 metoo
+			}
+		}`, false, Labeled{Metadata: "test", Labels: map[string]string{"test": "me", "test2": "metoo"}}},
+		{`labeled {
+			metadata test
+			label {
+				test me
+				test2 metoo
+			}
+			label inline works
+		}`, false, Labeled{Metadata: "test", Labels: map[string]string{"test": "me", "test2": "metoo", "inline": "works"}}},
+		{`labeled {
+			label inline works toomanyargs
+		}`, true, Labeled{Metadata: "test", Labels: map[string]string{"inline": "works"}}},
+	}
+
+	for i, test := range tests {
+		d := caddyfile.NewTestDispenser(test.input)
+		tun := Labeled{}
+		err := tun.UnmarshalCaddyfile(d)
+		tun.Provision(caddy.Context{})
+
+		if test.shouldErr {
+			if err == nil {
+				t.Errorf("Test %v: Expected error but found nil", i)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Test %v: Expected no error but found error: %v", i, err)
+			} else if test.expected.Metadata != tun.Metadata {
+				t.Errorf("Test %v: Created Labeled (\n%#v\n) does not match expected (\n%#v\n)", i, tun, test.expected)
+			} else if !reflect.DeepEqual(test.expected.Labels, tun.Labels) {
+				t.Errorf("Test %v: Created Labeled (\n%#v\n) does not match expected (\n%#v\n)", i, tun, test.expected)
+			}
+		}
+	}
+}

--- a/labeled_test.go
+++ b/labeled_test.go
@@ -16,7 +16,7 @@ func TestParseLabeled(t *testing.T) {
 	}{
 		{`labeled {
 			metadata test
-		}`, false, Labeled{Metadata: "test"}},
+		}`, false, Labeled{Metadata: "test", Labels: map[string]string{}}},
 		{`labeled {
 			metadata test
 			label test me

--- a/ngrok.go
+++ b/ngrok.go
@@ -140,11 +140,7 @@ func (n *Ngrok) doReplace() error {
 	}
 
 	for _, field := range replaceableFields {
-		actual, err := repl.ReplaceOrErr(*field, false, true)
-		if err != nil {
-			return fmt.Errorf("error replacing fields: %v", err)
-		}
-
+		actual := repl.ReplaceKnown(*field, "")
 		*field = actual
 	}
 

--- a/ngrok_test.go
+++ b/ngrok_test.go
@@ -1,10 +1,10 @@
 package ngroklistener
 
 import (
-	"time"
 	"encoding/json"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"


### PR DESCRIPTION
resolves https://github.com/mohammed90/caddy-ngrok-listener/issues/8

This PR adds the following:

- `Labeled` tunnel type.
- `lables` can be defined in a block:
```
label {
    edge edge_34242
    test labeltest
}
```
or inline:
```
label edge edge_34242
```
or a combination of both.

* Basic sanity tests for labeled tunnels.