### PR TITLE
Add addtional tunnel opts for http, tls, and tcp

### DIFF
--- a/http.go
+++ b/http.go
@@ -1,8 +1,12 @@
 package ngroklistener
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"go.uber.org/zap"
 	"golang.ngrok.com/ngrok/config"
 )
 
@@ -13,6 +17,35 @@ func init() {
 // ngrok HTTP tunnel
 type HTTP struct {
 	opts []config.HTTPEndpointOption
+
+	// Rejects connections that do not match the given CIDRs
+	AllowCIDR []string `json:"allowCidr,omitempty"`
+
+	// Rejects connections that match the given CIDRs and allows all other CIDRs.
+	DenyCIDR []string `json:"denyCidr,omitempty"`
+
+	// the domain for this edge.
+	Domain string `json:"domain,omitempty"`
+
+	// opaque metadata string for this tunnel.
+	Metadata string `json:"metadata,omitempty"`
+
+	// sets the scheme for this edge.
+	Scheme string `json:"scheme,omitempty"`
+
+	// the 5XX response ratio at which the ngrok edge will stop sending requests to this tunnel.
+	CircuitBreaker *float64 `json:"circuitBreaker,omitempty"`
+
+	// enables gzip compression.
+	EnableCompression bool `json:"enableCompression,omitempty"`
+
+	// enables the websocket-to-tcp converter.
+	EnableWebsocketTCPConversion bool `json:"enableWebsocketTcpConversion,omitempty"`
+
+	// A map of basicauth, username and password value pairs for this tunnel.
+	BasicAuth map[string]string `json:"basicauth,omitempty"`
+
+	l *zap.Logger
 }
 
 // CaddyModule implements caddy.Module
@@ -26,13 +59,116 @@ func (*HTTP) CaddyModule() caddy.ModuleInfo {
 }
 
 // Provision implements caddy.Provisioner
-func (*HTTP) Provision(caddy.Context) error {
+func (t *HTTP) Provision(ctx caddy.Context) error {
+	t.l = ctx.Logger()
+
+	if err := t.doReplace(); err != nil {
+		return fmt.Errorf("loading doing replacements: %v", err)
+	}
+
+	if err := t.provisionOpts(); err != nil {
+		return fmt.Errorf("provisioning http tunnel opts: %v", err)
+	}
+
+	return nil
+}
+
+func (t *HTTP) provisionOpts() error {
+	if t.Domain != "" {
+		t.opts = append(t.opts, config.WithDomain(t.Domain))
+	}
+
+	if t.Metadata != "" {
+		t.opts = append(t.opts, config.WithMetadata(t.Metadata))
+	}
+
+	if t.AllowCIDR != nil {
+		t.opts = append(t.opts, config.WithAllowCIDRString(t.AllowCIDR...))
+	}
+
+	if t.DenyCIDR != nil {
+		t.opts = append(t.opts, config.WithDenyCIDRString(t.DenyCIDR...))
+	}
+
+	if t.CircuitBreaker != nil {
+		t.opts = append(t.opts, config.WithCircuitBreaker(*t.CircuitBreaker))
+	}
+
+	if t.EnableCompression {
+		t.opts = append(t.opts, config.WithCompression())
+	}
+
+	if t.Scheme != "" {
+		if t.Scheme == "http" {
+			t.opts = append(t.opts, config.WithScheme(config.SchemeHTTP))
+		} else if t.Scheme == "https" {
+			t.opts = append(t.opts, config.WithScheme(config.SchemeHTTPS))
+		}
+	}
+
+	if t.EnableWebsocketTCPConversion {
+		t.opts = append(t.opts, config.WithWebsocketTCPConversion())
+	}
+
+	for username, password := range t.BasicAuth {
+		t.opts = append(t.opts, config.WithBasicAuth(username, password))
+	}
+
+	return nil
+}
+
+func (t *HTTP) doReplace() error {
+	repl := caddy.NewReplacer()
+	replaceableFields := []*string{
+		&t.Metadata,
+		&t.Domain,
+		&t.Scheme,
+	}
+
+	for _, field := range replaceableFields {
+		actual := repl.ReplaceKnown(*field, "")
+
+		*field = actual
+	}
+
+	replacedAllowCIDR := make([]string, len(t.AllowCIDR))
+
+	for index, cidr := range t.AllowCIDR {
+		actual := repl.ReplaceKnown(cidr, "")
+
+		replacedAllowCIDR[index] = actual
+	}
+
+	t.AllowCIDR = replacedAllowCIDR
+
+	replacedDenyCIDR := make([]string, len(t.DenyCIDR))
+
+	for index, cidr := range t.DenyCIDR {
+		actual := repl.ReplaceKnown(cidr, "")
+
+		replacedDenyCIDR[index] = actual
+	}
+
+	t.DenyCIDR = replacedDenyCIDR
+
+	replacedBasicAuth := make(map[string]string, len(t.BasicAuth))
+
+	for username, password := range t.BasicAuth {
+		actualUsername := repl.ReplaceKnown(username, "")
+
+		actualPassword := repl.ReplaceKnown(password, "")
+
+		replacedBasicAuth[actualUsername] = actualPassword
+	}
+
+	t.BasicAuth = replacedBasicAuth
+
 	return nil
 }
 
 // convert to ngrok's Tunnel type
-func (h *HTTP) NgrokTunnel() config.Tunnel {
-	return config.HTTPEndpoint(h.opts...)
+func (t *HTTP) NgrokTunnel() config.Tunnel {
+	return config.HTTPEndpoint(t.opts...)
 }
 
 func (t *HTTP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
@@ -40,17 +176,177 @@ func (t *HTTP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		if d.NextArg() {
 			return d.ArgErr()
 		}
-		for d.NextBlock(0) {
-			switch d.Val() {
+
+		for nesting := d.Nesting(); d.NextBlock(nesting); {
+			subdirective := d.Val()
+			switch subdirective {
+			case "domain":
+				if !d.AllArgs(&t.Domain) {
+					return d.ArgErr()
+				}
+			case "metadata":
+				if !d.AllArgs(&t.Metadata) {
+					return d.ArgErr()
+				}
+			case "allow":
+				if err := t.unmarshalAllowCidr(d); err != nil {
+					return err
+				}
+			case "deny":
+				if err := t.unmarshalDenyCidr(d); err != nil {
+					return err
+				}
+			case "circuit_breaker":
+				if err := t.unmarshalCircuitBreaker(d); err != nil {
+					return err
+				}
+			case "enable_compression":
+				if err := t.unmarshalEnableCompression(d); err != nil {
+					return err
+				}
+			case "scheme":
+				if !d.AllArgs(&t.Scheme) {
+					return d.ArgErr()
+				}
+			case "enable_websocket_tcp_conversion":
+				if err := t.unmarshalEnableWebsocketTCPConversion(d); err != nil {
+					return err
+				}
+			case "basicauth":
+				if err := t.unmarshalBasicAuth(d); err != nil {
+					return err
+				}
 			default:
 				return d.ArgErr()
 			}
 		}
 	}
+
 	return nil
 }
 
-var _ caddy.Module = (*HTTP)(nil)
-var _ Tunnel = (*HTTP)(nil)
-var _ caddy.Provisioner = (*HTTP)(nil)
-var _ caddyfile.Unmarshaler = (*HTTP)(nil)
+func (t *HTTP) unmarshalEnableWebsocketTCPConversion(d *caddyfile.Dispenser) error {
+	var value string
+	if !d.Args(&value) { // no arg default is true
+		t.EnableWebsocketTCPConversion = true
+	} else { // arg was given check it
+		var err error
+		t.EnableWebsocketTCPConversion, err = strconv.ParseBool(value)
+		if err != nil {
+			return d.Errf(`parsing enable_websocket_tcp_conversion value %+v: %w`, value, err)
+		}
+	}
+
+	return nil
+}
+
+func (t *HTTP) unmarshalEnableCompression(d *caddyfile.Dispenser) error {
+	var value string
+	if !d.Args(&value) { // no arg default is true
+		t.EnableCompression = true
+	} else { // arg was given check it
+		var err error
+		t.EnableCompression, err = strconv.ParseBool(value)
+		if err != nil {
+			return d.Errf(`parsing enable_compression value %+v: %w`, value, err)
+		}
+	}
+
+	return nil
+}
+
+func (t *HTTP) unmarshalAllowCidr(d *caddyfile.Dispenser) error {
+	if d.CountRemainingArgs() == 0 {
+		return d.ArgErr()
+	}
+
+	t.AllowCIDR = append(t.AllowCIDR, d.RemainingArgs()...)
+
+	return nil
+}
+
+func (t *HTTP) unmarshalDenyCidr(d *caddyfile.Dispenser) error {
+	if d.CountRemainingArgs() == 0 {
+		return d.ArgErr()
+	}
+
+	t.DenyCIDR = append(t.DenyCIDR, d.RemainingArgs()...)
+
+	return nil
+}
+
+func (t *HTTP) unmarshalBasicAuth(d *caddyfile.Dispenser) error {
+	var (
+		username string
+		password string
+	)
+
+	if t.BasicAuth == nil {
+		t.BasicAuth = map[string]string{}
+	}
+
+	minLenPassword := 8
+
+	username = d.Val()
+
+	if d.CountRemainingArgs() != 0 { // basicauth is defined inline
+		if !d.AllArgs(&username, &password) {
+			return d.ArgErr()
+		}
+
+		if username == "" || password == "" {
+			return d.Err("username and password cannot be empty or missing")
+		}
+
+		if len(password) < minLenPassword {
+			return d.Err("password must be at least eight characters.")
+		}
+
+		t.BasicAuth[username] = password
+
+		return nil
+	}
+
+	for nesting := d.Nesting(); d.NextBlock(nesting); { // block of basicauth
+		username := d.Val()
+
+		if !d.AllArgs(&password) {
+			return d.ArgErr()
+		}
+
+		if username == "" || password == "" {
+			return d.Err("username and password cannot be empty or missing")
+		}
+
+		if len(password) < minLenPassword {
+			return d.Err("password must be at least eight characters.")
+		}
+
+		t.BasicAuth[username] = password
+	}
+
+	return nil
+}
+
+func (t *HTTP) unmarshalCircuitBreaker(d *caddyfile.Dispenser) error {
+	var ratio string
+	if !d.AllArgs(&ratio) {
+		return d.ArgErr()
+	}
+
+	circuitBreaker, err := strconv.ParseFloat(ratio, 64)
+	if err != nil {
+		return d.ArgErr()
+	}
+
+	t.CircuitBreaker = &circuitBreaker
+
+	return nil
+}
+
+var (
+	_ caddy.Module          = (*HTTP)(nil)
+	_ Tunnel                = (*HTTP)(nil)
+	_ caddy.Provisioner     = (*HTTP)(nil)
+	_ caddyfile.Unmarshaler = (*HTTP)(nil)
+)

--- a/http_test.go
+++ b/http_test.go
@@ -53,6 +53,26 @@ func TestParseHTTP(t *testing.T) {
 			metadata test
 			deny
 		}`, true, HTTP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`http {
+			metadata test
+			compression
+			websocket_tcp_converter
+		}`, false, HTTP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}, Compression: true, WebsocketTCPConverter: true}},
+		{`http {
+			metadata test
+			compression true
+			websocket_tcp_converter true
+		}`, false, HTTP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}, Compression: true, WebsocketTCPConverter: true}},
+		{`http {
+			metadata test
+			compression false
+			websocket_tcp_converter false
+		}`, false, HTTP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}, Compression: false, WebsocketTCPConverter: false}},
+		{`http {
+			metadata test
+			compression off
+			websocket_tcp_converter off
+		}`, false, HTTP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}, Compression: false, WebsocketTCPConverter: false}},
 	}
 
 	for i, test := range tests {
@@ -76,6 +96,10 @@ func TestParseHTTP(t *testing.T) {
 				t.Errorf("Test %v: Created HTTP (\n%#v\n) does not match expected (\n%#v\n)", i, tun.AllowCIDR, test.expected.AllowCIDR)
 			} else if !reflect.DeepEqual(test.expected.DenyCIDR, tun.DenyCIDR) {
 				t.Errorf("Test %v: Created HTTP (\n%#v\n) does not match expected (\n%#v\n)", i, tun.DenyCIDR, test.expected.DenyCIDR)
+			} else if test.expected.Compression != tun.Compression {
+				t.Errorf("Test %v: Created HTTP (\n%#v\n) does not match expected (\n%#v\n)", i, tun.Compression, test.expected.Compression)
+			} else if test.expected.WebsocketTCPConverter != tun.WebsocketTCPConverter {
+				t.Errorf("Test %v: Created HTTP (\n%#v\n) does not match expected (\n%#v\n)", i, tun.WebsocketTCPConverter, test.expected.WebsocketTCPConverter)
 			}
 		}
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,82 @@
+package ngroklistener
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+)
+
+func TestParseHTTP(t *testing.T) {
+	tests := []struct {
+		input     string
+		shouldErr bool
+		expected  HTTP
+	}{
+		{`http {
+			metadata test
+		}`, false, HTTP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`http {
+			metadata test
+			domain test.domain.com
+		}`, false, HTTP{Metadata: "test", Domain: "test.domain.com", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`http {
+			metadata test
+			domain
+		}`, true, HTTP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`http {
+			metadata test
+			domain too manyargs
+		}`, true, HTTP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`http {
+			metadata test
+			allow 1
+		}`, false, HTTP{Metadata: "test", AllowCIDR: []string{"1"}, DenyCIDR: []string{}}},
+		{`http {
+			metadata test
+			allow 1 2 3
+		}`, false, HTTP{Metadata: "test", AllowCIDR: []string{"1", "2", "3"}, DenyCIDR: []string{}}},
+		{`http {
+			metadata test
+			allow
+		}`, true, HTTP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`http {
+			metadata test
+			deny 1
+		}`, false, HTTP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{"1"}}},
+		{`http {
+			metadata test
+			deny 1 2 3
+		}`, false, HTTP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{"1", "2", "3"}}},
+		{`http {
+			metadata test
+			deny
+		}`, true, HTTP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+	}
+
+	for i, test := range tests {
+		d := caddyfile.NewTestDispenser(test.input)
+		tun := HTTP{}
+		err := tun.UnmarshalCaddyfile(d)
+		tun.Provision(caddy.Context{})
+
+		if test.shouldErr {
+			if err == nil {
+				t.Errorf("Test %v: Expected error but found nil", i)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Test %v: Expected no error but found error: %v", i, err)
+			} else if test.expected.Metadata != tun.Metadata {
+				t.Errorf("Test %v: Created HTTP (\n%#v\n) does not match expected (\n%#v\n)", i, tun.Metadata, test.expected.Metadata)
+			} else if test.expected.Domain != tun.Domain {
+				t.Errorf("Test %v: Created HTTP (\n%#v\n) does not match expected (\n%#v\n)", i, tun.Domain, test.expected.Domain)
+			} else if !reflect.DeepEqual(test.expected.AllowCIDR, tun.AllowCIDR) {
+				t.Errorf("Test %v: Created HTTP (\n%#v\n) does not match expected (\n%#v\n)", i, tun.AllowCIDR, test.expected.AllowCIDR)
+			} else if !reflect.DeepEqual(test.expected.DenyCIDR, tun.DenyCIDR) {
+				t.Errorf("Test %v: Created HTTP (\n%#v\n) does not match expected (\n%#v\n)", i, tun.DenyCIDR, test.expected.DenyCIDR)
+			}
+		}
+	}
+}

--- a/ngrok.go
+++ b/ngrok.go
@@ -56,13 +56,13 @@ type Ngrok struct {
 	// before assuming the session connection is dead and attempting to reconnect.
 	//
 	// See the [heartbeat_tolerance parameter in the ngrok docs] for additional details.
-	HeartbeatTolerance caddy.Duration `json:"heartbeatTolerance,omitempty"`
+	HeartbeatTolerance caddy.Duration `json:"heartbeat_tolerance,omitempty"`
 
 	// HeartbeatInterval configures how often the session will send heartbeat
 	// messages to the ngrok service to check session liveness.
 	//
 	// See the [heartbeat_interval parameter in the ngrok docs] for additional details.
-	HeartbeatInterval caddy.Duration `json:"heartbeatInterval,omitempty"`
+	HeartbeatInterval caddy.Duration `json:"heartbeat_interval,omitempty"`
 
 	tunnel Tunnel
 

--- a/tcp.go
+++ b/tcp.go
@@ -18,16 +18,16 @@ type TCP struct {
 	opts []config.TCPEndpointOption
 
 	// The remote TCP address to request for this edge
-	RemoteAddr string `json:"remoteAddr,omitempty"`
+	RemoteAddr string `json:"remote_addr,omitempty"`
 
 	// opaque metadata string for this tunnel.
 	Metadata string `json:"metadata,omitempty"`
 
 	// Rejects connections that do not match the given CIDRs
-	AllowCIDR []string `json:"allowCidr,omitempty"`
+	AllowCIDR []string `json:"allow_cidr,omitempty"`
 
 	// Rejects connections that match the given CIDRs and allows all other CIDRs.
-	DenyCIDR []string `json:"denyCidr,omitempty"`
+	DenyCIDR []string `json:"deny_cidr,omitempty"`
 
 	l *zap.Logger
 }

--- a/tcp.go
+++ b/tcp.go
@@ -1,8 +1,11 @@
 package ngroklistener
 
 import (
+	"fmt"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"go.uber.org/zap"
 	"golang.ngrok.com/ngrok/config"
 )
 
@@ -12,15 +15,88 @@ func init() {
 
 // ngrok TCP tunnel
 type TCP struct {
-	// The TCP address to request for this edge
-	Address string `json:"address,omitempty"`
-
 	opts []config.TCPEndpointOption
+
+	// The remote TCP address to request for this edge
+	RemoteAddr string `json:"remoteAddr,omitempty"`
+
+	// opaque metadata string for this tunnel.
+	Metadata string `json:"metadata,omitempty"`
+
+	// Rejects connections that do not match the given CIDRs
+	AllowCIDR []string `json:"allowCidr,omitempty"`
+
+	// Rejects connections that match the given CIDRs and allows all other CIDRs.
+	DenyCIDR []string `json:"denyCidr,omitempty"`
+
+	l *zap.Logger
 }
 
 // Provision implements caddy.Provisioner
-func (t *TCP) Provision(caddy.Context) error {
-	t.opts = append(t.opts, config.WithRemoteAddr(t.Address))
+func (t *TCP) Provision(ctx caddy.Context) error {
+	t.l = ctx.Logger()
+
+	if err := t.doReplace(); err != nil {
+		return fmt.Errorf("loading doing replacements: %v", err)
+	}
+
+	if err := t.provisionOpts(); err != nil {
+		return fmt.Errorf("provisioning tcp tunnel opts: %v", err)
+	}
+
+	return nil
+}
+
+func (t *TCP) provisionOpts() error {
+	t.opts = append(t.opts, config.WithRemoteAddr(t.RemoteAddr))
+
+	if t.Metadata != "" {
+		t.opts = append(t.opts, config.WithMetadata(t.Metadata))
+	}
+
+	if t.AllowCIDR != nil {
+		t.opts = append(t.opts, config.WithAllowCIDRString(t.AllowCIDR...))
+	}
+
+	if t.DenyCIDR != nil {
+		t.opts = append(t.opts, config.WithDenyCIDRString(t.DenyCIDR...))
+	}
+
+	return nil
+}
+
+func (t *TCP) doReplace() error {
+	repl := caddy.NewReplacer()
+	replaceableFields := []*string{
+		&t.Metadata,
+	}
+
+	for _, field := range replaceableFields {
+		actual := repl.ReplaceKnown(*field, "")
+
+		*field = actual
+	}
+
+	replacedAllowCIDR := make([]string, len(t.AllowCIDR))
+
+	for index, cidr := range t.AllowCIDR {
+		actual := repl.ReplaceKnown(cidr, "")
+
+		replacedAllowCIDR[index] = actual
+	}
+
+	t.AllowCIDR = replacedAllowCIDR
+
+	replacedDenyCIDR := make([]string, len(t.DenyCIDR))
+
+	for index, cidr := range t.DenyCIDR {
+		actual := repl.ReplaceKnown(cidr, "")
+
+		replacedDenyCIDR[index] = actual
+	}
+
+	t.DenyCIDR = replacedDenyCIDR
+
 	return nil
 }
 
@@ -44,19 +120,42 @@ func (t *TCP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		if d.NextArg() {
 			return d.ArgErr()
 		}
-		for d.NextBlock(0) {
-			switch d.Val() {
-			case "address":
-				t.Address = d.Val()
+
+		for nesting := d.Nesting(); d.NextBlock(nesting); {
+			subdirective := d.Val()
+			switch subdirective {
+			case "metadata":
+				if !d.AllArgs(&t.Metadata) {
+					return d.ArgErr()
+				}
+			case "remote_addr":
+				if !d.AllArgs(&t.RemoteAddr) {
+					return d.ArgErr()
+				}
+			case "allow":
+				if d.CountRemainingArgs() == 0 {
+					return d.ArgErr()
+				}
+
+				t.AllowCIDR = append(t.AllowCIDR, d.RemainingArgs()...)
+			case "deny":
+				if d.CountRemainingArgs() == 0 {
+					return d.ArgErr()
+				}
+
+				t.DenyCIDR = append(t.DenyCIDR, d.RemainingArgs()...)
 			default:
 				return d.ArgErr()
 			}
 		}
 	}
+
 	return nil
 }
 
-var _ caddy.Module = (*TCP)(nil)
-var _ Tunnel = (*TCP)(nil)
-var _ caddy.Provisioner = (*TCP)(nil)
-var _ caddyfile.Unmarshaler = (*TCP)(nil)
+var (
+	_ caddy.Module          = (*TCP)(nil)
+	_ Tunnel                = (*TCP)(nil)
+	_ caddy.Provisioner     = (*TCP)(nil)
+	_ caddyfile.Unmarshaler = (*TCP)(nil)
+)

--- a/tcp_test.go
+++ b/tcp_test.go
@@ -1,0 +1,71 @@
+package ngroklistener
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+)
+
+func TestParseTCP(t *testing.T) {
+	tests := []struct {
+		input     string
+		shouldErr bool
+		expected  TCP
+	}{
+		{`tcp {
+			metadata test
+		}`, false, TCP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`tcp {
+			metadata test
+		}`, false, TCP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`tcp {
+			metadata test
+			allow 1
+		}`, false, TCP{Metadata: "test", AllowCIDR: []string{"1"}, DenyCIDR: []string{}}},
+		{`tcp {
+			metadata test
+			allow 1 2 3
+		}`, false, TCP{Metadata: "test", AllowCIDR: []string{"1", "2", "3"}, DenyCIDR: []string{}}},
+		{`tcp {
+			metadata test
+			allow
+		}`, true, TCP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`tcp {
+			metadata test
+			deny 1
+		}`, false, TCP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{"1"}}},
+		{`tcp {
+			metadata test
+			deny 1 2 3
+		}`, false, TCP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{"1", "2", "3"}}},
+		{`tcp {
+			metadata test
+			deny
+		}`, true, TCP{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+	}
+
+	for i, test := range tests {
+		d := caddyfile.NewTestDispenser(test.input)
+		tun := TCP{}
+		err := tun.UnmarshalCaddyfile(d)
+		tun.Provision(caddy.Context{})
+
+		if test.shouldErr {
+			if err == nil {
+				t.Errorf("Test %v: Expected error but found nil", i)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Test %v: Expected no error but found error: %v", i, err)
+			} else if test.expected.Metadata != tun.Metadata {
+				t.Errorf("Test %v: Created TCP (\n%#v\n) does not match expected (\n%#v\n)", i, tun.Metadata, test.expected.Metadata)
+			} else if !reflect.DeepEqual(test.expected.AllowCIDR, tun.AllowCIDR) {
+				t.Errorf("Test %v: Created TCP (\n%#v\n) does not match expected (\n%#v\n)", i, tun.AllowCIDR, test.expected.AllowCIDR)
+			} else if !reflect.DeepEqual(test.expected.DenyCIDR, tun.DenyCIDR) {
+				t.Errorf("Test %v: Created TCP (\n%#v\n) does not match expected (\n%#v\n)", i, tun.DenyCIDR, test.expected.DenyCIDR)
+			}
+		}
+	}
+}

--- a/tls.go
+++ b/tls.go
@@ -25,10 +25,10 @@ type TLS struct {
 	Metadata string `json:"metadata,omitempty"`
 
 	// Rejects connections that do not match the given CIDRs
-	AllowCIDR []string `json:"allowCidr,omitempty"`
+	AllowCIDR []string `json:"allow_cidr,omitempty"`
 
 	// Rejects connections that match the given CIDRs and allows all other CIDRs.
-	DenyCIDR []string `json:"denyCidr,omitempty"`
+	DenyCIDR []string `json:"deny_cidr,omitempty"`
 
 	l *zap.Logger
 }

--- a/tls.go
+++ b/tls.go
@@ -1,8 +1,11 @@
 package ngroklistener
 
 import (
+	"fmt"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"go.uber.org/zap"
 	"golang.ngrok.com/ngrok/config"
 )
 
@@ -14,6 +17,20 @@ func init() {
 // Note: only available for ngrok Enterprise user
 type TLS struct {
 	opts []config.TLSEndpointOption
+
+	// the domain for this edge.
+	Domain string `json:"domain,omitempty"`
+
+	// opaque metadata string for this tunnel.
+	Metadata string `json:"metadata,omitempty"`
+
+	// Rejects connections that do not match the given CIDRs
+	AllowCIDR []string `json:"allowCidr,omitempty"`
+
+	// Rejects connections that match the given CIDRs and allows all other CIDRs.
+	DenyCIDR []string `json:"denyCidr,omitempty"`
+
+	l *zap.Logger
 }
 
 // CaddyModule implements caddy.Module
@@ -27,7 +44,73 @@ func (*TLS) CaddyModule() caddy.ModuleInfo {
 }
 
 // Provision implements caddy.Provisioner
-func (t *TLS) Provision(caddy.Context) error {
+func (t *TLS) Provision(ctx caddy.Context) error {
+	t.l = ctx.Logger()
+
+	if err := t.doReplace(); err != nil {
+		return fmt.Errorf("loading doing replacements: %v", err)
+	}
+
+	if err := t.provisionOpts(); err != nil {
+		return fmt.Errorf("provisioning tls tunnel opts: %v", err)
+	}
+
+	return nil
+}
+
+func (t *TLS) provisionOpts() error {
+	if t.Domain != "" {
+		t.opts = append(t.opts, config.WithDomain(t.Domain))
+	}
+
+	if t.Metadata != "" {
+		t.opts = append(t.opts, config.WithMetadata(t.Metadata))
+	}
+
+	if t.AllowCIDR != nil {
+		t.opts = append(t.opts, config.WithAllowCIDRString(t.AllowCIDR...))
+	}
+
+	if t.DenyCIDR != nil {
+		t.opts = append(t.opts, config.WithDenyCIDRString(t.DenyCIDR...))
+	}
+
+	return nil
+}
+
+func (t *TLS) doReplace() error {
+	repl := caddy.NewReplacer()
+	replaceableFields := []*string{
+		&t.Metadata,
+		&t.Domain,
+	}
+
+	for _, field := range replaceableFields {
+		actual := repl.ReplaceKnown(*field, "")
+
+		*field = actual
+	}
+
+	replacedAllowCIDR := make([]string, len(t.AllowCIDR))
+
+	for index, cidr := range t.AllowCIDR {
+		actual := repl.ReplaceKnown(cidr, "")
+
+		replacedAllowCIDR[index] = actual
+	}
+
+	t.AllowCIDR = replacedAllowCIDR
+
+	replacedDenyCIDR := make([]string, len(t.DenyCIDR))
+
+	for index, cidr := range t.DenyCIDR {
+		actual := repl.ReplaceKnown(cidr, "")
+
+		replacedDenyCIDR[index] = actual
+	}
+
+	t.DenyCIDR = replacedDenyCIDR
+
 	return nil
 }
 
@@ -41,17 +124,58 @@ func (t *TLS) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		if d.NextArg() {
 			return d.ArgErr()
 		}
-		for d.NextBlock(0) {
-			switch d.Val() {
+
+		for nesting := d.Nesting(); d.NextBlock(nesting); {
+			subdirective := d.Val()
+			switch subdirective {
+			case "domain":
+				if !d.AllArgs(&t.Domain) {
+					return d.ArgErr()
+				}
+			case "metadata":
+				if !d.AllArgs(&t.Metadata) {
+					return d.ArgErr()
+				}
+			case "allow":
+				if err := t.unmarshalAllowCidr(d); err != nil {
+					return err
+				}
+			case "deny":
+				if err := t.unmarshalDenyCidr(d); err != nil {
+					return err
+				}
 			default:
 				return d.ArgErr()
 			}
 		}
 	}
+
 	return nil
 }
 
-var _ caddy.Module = (*TLS)(nil)
-var _ Tunnel = (*TLS)(nil)
-var _ caddy.Provisioner = (*TLS)(nil)
-var _ caddyfile.Unmarshaler = (*TLS)(nil)
+func (t *TLS) unmarshalAllowCidr(d *caddyfile.Dispenser) error {
+	if d.CountRemainingArgs() == 0 {
+		return d.ArgErr()
+	}
+
+	t.AllowCIDR = append(t.AllowCIDR, d.RemainingArgs()...)
+
+	return nil
+}
+
+func (t *TLS) unmarshalDenyCidr(d *caddyfile.Dispenser) error {
+	if d.CountRemainingArgs() == 0 {
+		return d.ArgErr()
+	}
+
+	t.DenyCIDR = append(t.DenyCIDR, d.RemainingArgs()...)
+
+	return nil
+}
+
+var (
+	_ caddy.Module          = (*TLS)(nil)
+	_ Tunnel                = (*TLS)(nil)
+	_ caddy.Provisioner     = (*TLS)(nil)
+	_ caddyfile.Unmarshaler = (*TLS)(nil)
+)

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,0 +1,82 @@
+package ngroklistener
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+)
+
+func TestParseTLS(t *testing.T) {
+	tests := []struct {
+		input     string
+		shouldErr bool
+		expected  TLS
+	}{
+		{`tls {
+			metadata test
+		}`, false, TLS{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`tls {
+			metadata test
+			domain test.domain.com
+		}`, false, TLS{Metadata: "test", Domain: "test.domain.com", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`tls {
+			metadata test
+			domain
+		}`, true, TLS{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`tls {
+			metadata test
+			domain too manyargs
+		}`, true, TLS{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`tls {
+			metadata test
+			allow 1
+		}`, false, TLS{Metadata: "test", AllowCIDR: []string{"1"}, DenyCIDR: []string{}}},
+		{`tls {
+			metadata test
+			allow 1 2 3
+		}`, false, TLS{Metadata: "test", AllowCIDR: []string{"1", "2", "3"}, DenyCIDR: []string{}}},
+		{`tls {
+			metadata test
+			allow
+		}`, true, TLS{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+		{`tls {
+			metadata test
+			deny 1
+		}`, false, TLS{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{"1"}}},
+		{`tls {
+			metadata test
+			deny 1 2 3
+		}`, false, TLS{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{"1", "2", "3"}}},
+		{`tls {
+			metadata test
+			deny
+		}`, true, TLS{Metadata: "test", AllowCIDR: []string{}, DenyCIDR: []string{}}},
+	}
+
+	for i, test := range tests {
+		d := caddyfile.NewTestDispenser(test.input)
+		tun := TLS{}
+		err := tun.UnmarshalCaddyfile(d)
+		tun.Provision(caddy.Context{})
+
+		if test.shouldErr {
+			if err == nil {
+				t.Errorf("Test %v: Expected error but found nil", i)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Test %v: Expected no error but found error: %v", i, err)
+			} else if test.expected.Metadata != tun.Metadata {
+				t.Errorf("Test %v: Created TLS (\n%#v\n) does not match expected (\n%#v\n)", i, tun.Metadata, test.expected.Metadata)
+			} else if test.expected.Domain != tun.Domain {
+				t.Errorf("Test %v: Created TLS (\n%#v\n) does not match expected (\n%#v\n)", i, tun.Domain, test.expected.Domain)
+			} else if !reflect.DeepEqual(test.expected.AllowCIDR, tun.AllowCIDR) {
+				t.Errorf("Test %v: Created TLS (\n%#v\n) does not match expected (\n%#v\n)", i, tun.AllowCIDR, test.expected.AllowCIDR)
+			} else if !reflect.DeepEqual(test.expected.DenyCIDR, tun.DenyCIDR) {
+				t.Errorf("Test %v: Created TLS (\n%#v\n) does not match expected (\n%#v\n)", i, tun.DenyCIDR, test.expected.DenyCIDR)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds the following:

- Additional items to the todo file covering what ngrok-go options aren't handled
- Adds the following fields to the `http` tunnel type
    - AllowCIDR
    - DenyCIDR
    - Domain
    - Metadata
    - Scheme
    - CircuitBreaker
    - EnableCompression
    - EnableWebsocketTCPConversion
    - BasicAuth
- Handles replacement for the fields on `http`. 
- Adds the following fields to the `tcp` tunnel type
    - AllowCIDR
    - DenyCIDR
    - RemoteAddr
    - Metadata
- Handles replacement for the fields on `tcp`.
- Adds the following fields to the `tls` tunnel type
    - AllowCIDR
    - DenyCIDR
    - Domain
    - Metadata
- Handles replacement for the fields on `tls`.
- Some basic tests for `http`, `tls`, and `tcp` tunnels.