### PR TITLE
core: proxy url support

### DIFF
--- a/ngrok.go
+++ b/ngrok.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/url"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
@@ -63,6 +64,14 @@ type Ngrok struct {
 	//
 	// See the [heartbeat_interval parameter in the ngrok docs] for additional details.
 	HeartbeatInterval caddy.Duration `json:"heartbeat_interval,omitempty"`
+
+	// https://github.com/ngrok/ngrok-go/blob/main/session.go
+	// ProxyURL configures the session to connect to ngrok through an outbound
+	// HTTP or SOCKS5 proxy. This parameter is ignored if you override the dialer
+	// with [WithDialer].
+	//
+	// See the [proxy url parameter in the ngrok docs] for additional details.
+	ProxyURL string `json:"proxy_url,omitempty"`
 
 	tunnel Tunnel
 
@@ -125,6 +134,14 @@ func (n *Ngrok) provisionOpts() error {
 
 	n.opts = append(n.opts, ngrok.WithHeartbeatTolerance(time.Duration(n.HeartbeatTolerance)))
 
+	if n.ProxyURL != "" {
+		url, err := url.Parse(n.ProxyURL)
+		if err != nil {
+			return fmt.Errorf("provisioning proxy_url: %v", err)
+		}
+		n.opts = append(n.opts, ngrok.WithProxyURL(url))
+	}
+
 	return nil
 }
 
@@ -135,6 +152,7 @@ func (n *Ngrok) doReplace() {
 		&n.Metadata,
 		&n.Region,
 		&n.Server,
+		&n.ProxyURL,
 	}
 
 	for _, field := range replaceableFields {
@@ -200,6 +218,10 @@ func (n *Ngrok) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			case "heartbeat_interval":
 				if err := n.unmarshalHeartbeatInterval(d); err != nil {
 					return err
+				}
+			case "proxy_url":
+				if !d.AllArgs(&n.ProxyURL) {
+					return d.ArgErr()
 				}
 			case "tunnel":
 				if err := n.unmarshalTunnel(d); err != nil {

--- a/ngrok_test.go
+++ b/ngrok_test.go
@@ -227,6 +227,53 @@ func TestNgrokHeartbeat(t *testing.T) {
 	cases.runAll(t)
 }
 
+func TestNgrokProxyUrl(t *testing.T) {
+	cases := genericNgrokTestCases[*Ngrok]{
+		{
+			name: "empty",
+			caddyInput: `ngrok {
+			}`,
+			expectConfig: func(t *testing.T, actual *Ngrok) {
+				require.Empty(t, actual.ProxyURL)
+			},
+		},
+		{
+			name: "set proxy_url",
+			caddyInput: `ngrok {
+				proxy_url http://proxy.url
+			}`,
+			expectConfig: func(t *testing.T, actual *Ngrok) {
+				require.Equal(t, actual.ProxyURL, "http://proxy.url")
+			},
+		},
+		{
+			name: "proxy_url-no-arg",
+			caddyInput: `ngrok {
+				proxy_url
+			}`,
+			expectUnmarshalErr: true,
+		},
+		{
+			name: "proxy_url-too-many-arg",
+			caddyInput: `ngrok {
+				proxy_url http://proxy.url http://proxy2.url
+			}`,
+			expectUnmarshalErr: true,
+		},
+		{
+			name: "proxy_url-non-url",
+			caddyInput: `ngrok {
+				proxy_url 123.456.789.101:1234
+			}`,
+			expectConfig: func(t *testing.T, actual *Ngrok) {
+				require.Equal(t, actual.ProxyURL, "123.456.789.101:1234")
+			},
+			expectProvisionErr: true,
+		},
+	}
+	cases.runAll(t)
+}
+
 func TestNgrokTunnel(t *testing.T) {
 	cases := genericNgrokTestCases[*Ngrok]{
 		{


### PR DESCRIPTION
This one was much simpler than even previous thoughts. Kept it as a string until provision time so that replacers could be run on it. 

Resolves https://github.com/mohammed90/caddy-ngrok-listener/issues/6

