### PR TITLE
refactor: convert options into parametric Caddy modules

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -1,8 +1,10 @@
 package ngroklistener
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/stretchr/testify/require"
 	"golang.ngrok.com/ngrok/config"
 )
@@ -196,7 +198,7 @@ func TestHTTPCircuitBreaker(t *testing.T) {
 			caddyInput: `http {
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Zero(t, actual.CircuitBreaker)
+				require.Zero(t, actual.Options["circuit_breaker"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithCircuitBreaker(0),
@@ -208,7 +210,7 @@ func TestHTTPCircuitBreaker(t *testing.T) {
 				circuit_breaker 0.5
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Equal(t, actual.CircuitBreaker, 0.5)
+				require.Equal(t, caddy.ModuleMap{"circuit_breaker": json.RawMessage(`0.5`)}, actual.Options)
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithCircuitBreaker(0.5),
@@ -248,7 +250,7 @@ func TestHTTPCompression(t *testing.T) {
 			caddyInput: `http {
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.False(t, actual.Compression)
+				require.Zero(t, actual.Options["compression"])
 			},
 			expectedOpts: config.HTTPEndpoint(),
 		},
@@ -258,7 +260,7 @@ func TestHTTPCompression(t *testing.T) {
 				compression off
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.False(t, actual.Compression)
+				require.Equal(t, json.RawMessage(`false`), actual.Options["compression"])
 			},
 			expectedOpts: config.HTTPEndpoint(),
 		},
@@ -268,7 +270,7 @@ func TestHTTPCompression(t *testing.T) {
 				compression false
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.False(t, actual.Compression)
+				require.Equal(t, json.RawMessage(`false`), actual.Options["compression"])
 			},
 			expectedOpts: config.HTTPEndpoint(),
 		},
@@ -278,7 +280,7 @@ func TestHTTPCompression(t *testing.T) {
 				compression true
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.True(t, actual.Compression)
+				require.Equal(t, json.RawMessage(`true`), actual.Options["compression"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithCompression(),
@@ -290,7 +292,7 @@ func TestHTTPCompression(t *testing.T) {
 				compression
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.True(t, actual.Compression)
+				require.Equal(t, json.RawMessage(`true`), actual.Options["compression"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithCompression(),
@@ -323,7 +325,7 @@ func TestHTTPWebsocketTCPConversion(t *testing.T) {
 			caddyInput: `http {
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.False(t, actual.WebsocketTCPConverter)
+				require.Zero(t, actual.Options["websocket_tcp_conversion"])
 			},
 			expectedOpts: config.HTTPEndpoint(),
 		},
@@ -333,7 +335,7 @@ func TestHTTPWebsocketTCPConversion(t *testing.T) {
 				websocket_tcp_converter off
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.False(t, actual.WebsocketTCPConverter)
+				require.Equal(t, json.RawMessage(`false`), actual.Options["websocket_tcp_conversion"])
 			},
 			expectedOpts: config.HTTPEndpoint(),
 		},
@@ -343,7 +345,7 @@ func TestHTTPWebsocketTCPConversion(t *testing.T) {
 				websocket_tcp_converter false
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.False(t, actual.WebsocketTCPConverter)
+				require.Equal(t, json.RawMessage(`false`), actual.Options["websocket_tcp_conversion"])
 			},
 			expectedOpts: config.HTTPEndpoint(),
 		},
@@ -353,7 +355,7 @@ func TestHTTPWebsocketTCPConversion(t *testing.T) {
 				websocket_tcp_converter true
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.True(t, actual.WebsocketTCPConverter)
+				require.Equal(t, json.RawMessage(`true`), actual.Options["websocket_tcp_conversion"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithWebsocketTCPConversion(),
@@ -365,7 +367,7 @@ func TestHTTPWebsocketTCPConversion(t *testing.T) {
 				websocket_tcp_converter
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.True(t, actual.WebsocketTCPConverter)
+				require.Equal(t, json.RawMessage(`true`), actual.Options["websocket_tcp_conversion"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithWebsocketTCPConversion(),
@@ -398,7 +400,7 @@ func TestHTTPDomain(t *testing.T) {
 			caddyInput: `http {
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Empty(t, actual.Domain)
+				require.Empty(t, actual.Options["domain"])
 			},
 			expectedOpts: config.HTTPEndpoint(),
 		},
@@ -408,7 +410,7 @@ func TestHTTPDomain(t *testing.T) {
 				domain foo.ngrok.io
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Equal(t, actual.Domain, "foo.ngrok.io")
+				require.Equal(t, json.RawMessage(`"foo.ngrok.io"`), actual.Options["domain"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithDomain("foo.ngrok.io"),
@@ -441,7 +443,7 @@ func TestHTTPMetadata(t *testing.T) {
 			caddyInput: `http {
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Empty(t, actual.Metadata)
+				require.Empty(t, actual.Options["metadata"])
 			},
 			expectedOpts: config.HTTPEndpoint(),
 		},
@@ -451,7 +453,7 @@ func TestHTTPMetadata(t *testing.T) {
 				metadata test
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Equal(t, actual.Metadata, "test")
+				require.Equal(t, json.RawMessage(quoteString("test")), actual.Options["metadata"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithMetadata("test"),
@@ -463,7 +465,7 @@ func TestHTTPMetadata(t *testing.T) {
 				metadata "Hello, World!"
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Equal(t, actual.Metadata, "Hello, World!")
+				require.Equal(t, json.RawMessage(quoteString("Hello, World!")), actual.Options["metadata"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithMetadata("Hello, World!"),
@@ -497,7 +499,7 @@ func TestHTTPScheme(t *testing.T) {
 			}`,
 			expectUnmarshalErr: false,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Empty(t, actual.Scheme)
+				require.Empty(t, actual.Options["scheme"])
 			},
 			expectedOpts: config.HTTPEndpoint(),
 		},
@@ -508,7 +510,7 @@ func TestHTTPScheme(t *testing.T) {
 			}`,
 			expectUnmarshalErr: false,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Equal(t, "https", actual.Scheme)
+				require.Equal(t, json.RawMessage(`"https"`), actual.Options["scheme"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithScheme("https"),
@@ -521,7 +523,7 @@ func TestHTTPScheme(t *testing.T) {
 			}`,
 			expectUnmarshalErr: false,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Equal(t, "http", actual.Scheme)
+				require.Equal(t, json.RawMessage(`"http"`), actual.Options["scheme"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithScheme("http"),
@@ -534,7 +536,7 @@ func TestHTTPScheme(t *testing.T) {
 			}`,
 			expectUnmarshalErr: false,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Equal(t, "foo", actual.Scheme)
+				require.Equal(t, json.RawMessage(`"foo"`), actual.Options["scheme"])
 			},
 			expectProvisionErr: true,
 		},
@@ -565,8 +567,8 @@ func TestHTTPCIDRRestrictions(t *testing.T) {
 			caddyInput: `http {
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Empty(t, actual.AllowCIDR)
-				require.Empty(t, actual.DenyCIDR)
+				require.Empty(t, actual.Options["allow_cidr"])
+				require.Empty(t, actual.Options["deny_cidr"])
 			},
 			expectedOpts: config.HTTPEndpoint(),
 		},
@@ -576,8 +578,8 @@ func TestHTTPCIDRRestrictions(t *testing.T) {
 				allow 127.0.0.0/8
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.ElementsMatch(t, actual.AllowCIDR, []string{"127.0.0.0/8"})
-				require.Empty(t, actual.DenyCIDR)
+				require.JSONEq(t, `["127.0.0.0/8"]`, string(actual.Options["allow_cidr"]))
+				require.Empty(t, actual.Options["deny_cidr"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithAllowCIDRString("127.0.0.0/8"),
@@ -589,8 +591,8 @@ func TestHTTPCIDRRestrictions(t *testing.T) {
 				deny 127.0.0.0/8
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Empty(t, actual.AllowCIDR)
-				require.ElementsMatch(t, actual.DenyCIDR, []string{"127.0.0.0/8"})
+				require.Empty(t, actual.Options["allow_cidr"])
+				require.JSONEq(t, `["127.0.0.0/8"]`, string(actual.Options["deny_cidr"]))
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithDenyCIDRString("127.0.0.0/8"),
@@ -603,8 +605,8 @@ func TestHTTPCIDRRestrictions(t *testing.T) {
 				allow 10.0.0.0/8
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.ElementsMatch(t, actual.AllowCIDR, []string{"127.0.0.0/8", "10.0.0.0/8"})
-				require.Empty(t, actual.DenyCIDR)
+				require.JSONEq(t, `["127.0.0.0/8", "10.0.0.0/8"]`, string(actual.Options["allow_cidr"]))
+				require.Empty(t, actual.Options["deny_cidr"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithAllowCIDRString("127.0.0.0/8", "10.0.0.0/8"),
@@ -616,8 +618,8 @@ func TestHTTPCIDRRestrictions(t *testing.T) {
 				allow 127.0.0.0/8 10.0.0.0/8
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.ElementsMatch(t, actual.AllowCIDR, []string{"127.0.0.0/8", "10.0.0.0/8"})
-				require.Empty(t, actual.DenyCIDR)
+				require.JSONEq(t, `["127.0.0.0/8", "10.0.0.0/8"]`, string(actual.Options["allow_cidr"]))
+				require.Empty(t, actual.Options["deny_cidr"])
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithAllowCIDRString("127.0.0.0/8", "10.0.0.0/8"),
@@ -630,8 +632,8 @@ func TestHTTPCIDRRestrictions(t *testing.T) {
 				deny 10.0.0.0/8
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Empty(t, actual.AllowCIDR)
-				require.ElementsMatch(t, actual.DenyCIDR, []string{"127.0.0.0/8", "10.0.0.0/8"})
+				require.Empty(t, actual.Options["allow_cidr"])
+				require.JSONEq(t, `["127.0.0.0/8", "10.0.0.0/8"]`, string(actual.Options["deny_cidr"]))
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithDenyCIDRString("127.0.0.0/8", "10.0.0.0/8"),
@@ -643,8 +645,8 @@ func TestHTTPCIDRRestrictions(t *testing.T) {
 				deny 127.0.0.0/8 10.0.0.0/8
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.Empty(t, actual.AllowCIDR)
-				require.ElementsMatch(t, actual.DenyCIDR, []string{"127.0.0.0/8", "10.0.0.0/8"})
+				require.Empty(t, actual.Options["allow_cidr"])
+				require.JSONEq(t, `["127.0.0.0/8", "10.0.0.0/8"]`, string(actual.Options["deny_cidr"]))
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithDenyCIDRString("127.0.0.0/8", "10.0.0.0/8"),
@@ -659,8 +661,8 @@ func TestHTTPCIDRRestrictions(t *testing.T) {
 				deny 172.0.0.0/8
 			}`,
 			expectConfig: func(t *testing.T, actual *HTTP) {
-				require.ElementsMatch(t, actual.AllowCIDR, []string{"127.0.0.0/8", "10.0.0.0/8"})
-				require.ElementsMatch(t, actual.DenyCIDR, []string{"192.0.0.0/8", "172.0.0.0/8"})
+				require.JSONEq(t, `["127.0.0.0/8", "10.0.0.0/8"]`, string(actual.Options["allow_cidr"]))
+				require.JSONEq(t, `["192.0.0.0/8", "172.0.0.0/8"]`, string(actual.Options["deny_cidr"]))
 			},
 			expectedOpts: config.HTTPEndpoint(
 				config.WithAllowCIDRString("127.0.0.0/8", "10.0.0.0/8"),

--- a/httpoptions.go
+++ b/httpoptions.go
@@ -1,0 +1,249 @@
+package ngroklistener
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/caddyserver/caddy/v2"
+	"golang.ngrok.com/ngrok/config"
+)
+
+func init() {
+	caddy.RegisterModule(AllowCIDR{})
+	caddy.RegisterModule(DenyCIDR{})
+	caddy.RegisterModule(HTTPDomain(""))
+	caddy.RegisterModule(HTTPMetadata(""))
+	caddy.RegisterModule(HTTPScheme(""))
+	caddy.RegisterModule(HTTPCircuitBreaker(0))
+	caddy.RegisterModule(HTTPCompression(false))
+	caddy.RegisterModule(HTTPWebsocketTCPConversion(false))
+}
+
+type HTTPOptioner interface {
+	HTTPOption() config.HTTPEndpointOption
+}
+
+// Rejects connections that do not match the given CIDRs
+type AllowCIDR []string
+
+// Provision implements caddy.Provisioner
+func (ac AllowCIDR) Provision(ctx caddy.Context) error {
+	repl := caddy.NewReplacer()
+	for index, cidr := range ac {
+		actual := repl.ReplaceKnown(cidr, "")
+		ac[index] = actual
+	}
+	return nil
+}
+
+// CaddyModule implements caddy.Module
+func (AllowCIDR) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "caddy.listeners.ngrok.tunnels.http.options.allow_cidr",
+		New: func() caddy.Module {
+			return AllowCIDR{}
+		},
+	}
+}
+func (a AllowCIDR) HTTPOption() config.HTTPEndpointOption {
+	if len(a) <= 0 {
+		return nil
+	}
+	return config.WithAllowCIDRString(a...)
+}
+
+// Rejects connections that match the given CIDRs and allows all other CIDRs.
+type DenyCIDR []string
+
+// Provision implements caddy.Provisioner
+func (dc DenyCIDR) Provision(caddy.Context) error {
+	repl := caddy.NewReplacer()
+	for index, cidr := range dc {
+		actual := repl.ReplaceKnown(cidr, "")
+		dc[index] = actual
+	}
+	return nil
+}
+
+// CaddyModule implements caddy.Module
+func (DenyCIDR) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "caddy.listeners.ngrok.tunnels.http.options.deny_cidr",
+		New: func() caddy.Module {
+			return new(DenyCIDR)
+		},
+	}
+}
+func (a DenyCIDR) HTTPOption() config.HTTPEndpointOption {
+	if len(a) <= 0 {
+		return nil
+	}
+	return config.WithDenyCIDRString(a...)
+}
+
+// the domain for this edge
+type HTTPDomain string
+
+// Provision implements caddy.Provisioner
+func (hd HTTPDomain) Provision(ctx caddy.Context) error {
+	repl := caddy.NewReplacer()
+	hd = HTTPDomain(repl.ReplaceKnown(string(hd), ""))
+	return nil
+}
+
+func (HTTPDomain) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "caddy.listeners.ngrok.tunnels.http.options.domain",
+		New: func() caddy.Module {
+			return new(HTTPDomain)
+		},
+	}
+}
+func (a HTTPDomain) HTTPOption() config.HTTPEndpointOption {
+	return config.WithDomain(string(a))
+}
+
+// opaque metadata string for this tunnel
+type HTTPMetadata string
+
+func (HTTPMetadata) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "caddy.listeners.ngrok.tunnels.http.options.metadata",
+		New: func() caddy.Module {
+			return new(HTTPMetadata)
+		},
+	}
+}
+
+// Provision implements caddy.Provisioner
+func (hm HTTPMetadata) Provision(caddy.Context) error {
+	repl := caddy.NewReplacer()
+	hm = HTTPMetadata(repl.ReplaceKnown(string(hm), ""))
+	return nil
+}
+
+func (a HTTPMetadata) HTTPOption() config.HTTPEndpointOption {
+	return config.WithMetadata(string(a))
+}
+
+// sets the scheme for this edge
+type HTTPScheme string
+
+// Provision implements caddy.Provisioner
+func (hs HTTPScheme) Provision(caddy.Context) error {
+	repl := caddy.NewReplacer()
+	hs = HTTPScheme(repl.ReplaceKnown(string(hs), ""))
+	return nil
+}
+
+func (HTTPScheme) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "caddy.listeners.ngrok.tunnels.http.options.scheme",
+		New: func() caddy.Module {
+			return new(HTTPScheme)
+		},
+	}
+}
+
+func (a HTTPScheme) Validate() error {
+	switch s := strings.ToLower(strings.TrimSpace(string(a))); s {
+	case "http", "https":
+		return nil
+	default:
+		return fmt.Errorf("unrecognized http tunnel scheme: %s", a)
+	}
+}
+
+func (a HTTPScheme) HTTPOption() config.HTTPEndpointOption {
+	var scheme config.Scheme
+	switch s := strings.ToLower(strings.TrimSpace(string(a))); s {
+	case "http":
+		scheme = config.SchemeHTTP
+	case "https":
+		scheme = config.SchemeHTTPS
+	}
+	return config.WithScheme(scheme)
+}
+
+// the 5XX response ratio at which the ngrok edge will stop sending requests to this tunnel.
+type HTTPCircuitBreaker float64
+
+// CaddyModule implements caddy.Module
+func (HTTPCircuitBreaker) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "caddy.listeners.ngrok.tunnels.http.options.circuit_breaker",
+		New: func() caddy.Module {
+			return new(HTTPCircuitBreaker)
+		},
+	}
+}
+
+// HTTPOption implements HTTPOptioner
+func (hcb HTTPCircuitBreaker) HTTPOption() config.HTTPEndpointOption {
+	return config.WithCircuitBreaker(float64(hcb))
+}
+
+// enables gzip compression
+type HTTPCompression bool
+
+// CaddyModule implements caddy.Module
+func (HTTPCompression) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "caddy.listeners.ngrok.tunnels.http.options.compression",
+		New: func() caddy.Module {
+			return new(HTTPCompression)
+		},
+	}
+}
+
+// HTTPOption implements HTTPOptioner
+func (hc HTTPCompression) HTTPOption() config.HTTPEndpointOption {
+	if hc {
+		return config.WithCompression()
+	}
+	return nil
+}
+
+// enables the websocket-to-tcp converter
+type HTTPWebsocketTCPConversion bool
+
+// CaddyModule implements caddy.Module
+func (HTTPWebsocketTCPConversion) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID: "caddy.listeners.ngrok.tunnels.http.options.websocket_tcp_converter",
+		New: func() caddy.Module {
+			return new(HTTPWebsocketTCPConversion)
+		},
+	}
+}
+
+// HTTPOption implements HTTPOptioner
+func (hwtc HTTPWebsocketTCPConversion) HTTPOption() config.HTTPEndpointOption {
+	if hwtc {
+		return config.WithWebsocketTCPConversion()
+	}
+	return nil
+}
+
+var _ caddy.Module = AllowCIDR{}
+var _ caddy.Provisioner = AllowCIDR{}
+var _ HTTPOptioner = AllowCIDR{}
+var _ caddy.Module = DenyCIDR{}
+var _ caddy.Provisioner = DenyCIDR{}
+var _ HTTPOptioner = DenyCIDR{}
+var _ caddy.Module = HTTPDomain("")
+var _ caddy.Provisioner = HTTPDomain("")
+var _ HTTPDomain = HTTPDomain("")
+var _ caddy.Module = HTTPMetadata("")
+var _ caddy.Provisioner = HTTPMetadata("")
+var _ HTTPOptioner = HTTPMetadata("")
+var _ caddy.Module = HTTPScheme("")
+var _ caddy.Provisioner = HTTPScheme("")
+var _ caddy.Validator = HTTPScheme("")
+var _ HTTPOptioner = HTTPScheme("")
+var _ caddy.Module = HTTPCircuitBreaker(0)
+var _ HTTPOptioner = HTTPCircuitBreaker(0)
+var _ caddy.Module = HTTPCompression(false)
+var _ HTTPOptioner = HTTPCompression(false)
+var _ caddy.Module = HTTPWebsocketTCPConversion(false)
+var _ HTTPOptioner = HTTPWebsocketTCPConversion(false)

--- a/ngrok.go
+++ b/ngrok.go
@@ -268,6 +268,10 @@ func (n *Ngrok) unmarshalTunnel(d *caddyfile.Dispenser) error {
 	return nil
 }
 
+func quoteString(v string) string {
+	return `"` + v + `"`
+}
+
 var (
 	_ caddy.Module          = (*Ngrok)(nil)
 	_ caddy.Provisioner     = (*Ngrok)(nil)


### PR DESCRIPTION
This changes the structure of the JSON config from, e.g.:

```json
{
	"apps":{
		"http": {
			"servers": {
				"srv0": {
					"listen": [":443"],
					"listener_wrappers": [
						{
							"wrapper": "ngrok",
							"authtoken": "",
							"tunnel": {
								"type": "http",
								"metadata": "some-metadata"
							}
						}
					]
				}
			}
		}
	}
}
```

To:

```json
{
	"apps":{
		"http": {
			"servers": {
				"srv0": {
					"listen": [":443"],
					"listener_wrappers": [
						{
							"wrapper": "ngrok",
							"authtoken": "",
							"tunnel": {
								"type": "http",
								"options": {
									"metadata": "some-metadata"
								}
							}
						}
					]
				}
			}
		}
	}
}
```

It feels more ergonomic, allows for future complex options to benefit form Caddy's module lifecycle, and allows the user to examine the available options when running `caddy list-modules`.

@jtszalay, thoughts? I had this idea when I saw the complexity in OIDC option in PR #17.

Note: The Caddyfile-unmarshaller of the {Allow,Deny}CIDR still needs to be fixed. That's a bit more hairy to resolve.