### PR TITLE
Core: Change `authtoken` to `auth_token` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently, the module does not support the extended ngrok options, e.g. allow/de
 	servers :80 {
 		listener_wrappers {
 			ngrok {
-				authtoken $NGROK_AUTH_TOKEN
+				auth_token $NGROK_AUTH_TOKEN
 				tunnel http {
 				}
 			}

--- a/ngrok.go
+++ b/ngrok.go
@@ -29,7 +29,7 @@ type Ngrok struct {
 	opts []ngrok.ConnectOption
 
 	// The user's ngrok authentication token
-	AuthToken string `json:"authtoken,omitempty"`
+	AuthToken string `json:"auth_token,omitempty"`
 
 	// The ngrok tunnel type and configuration; defaults to 'tcp'
 	TunnelRaw json.RawMessage `json:"tunnel,omitempty" caddy:"namespace=caddy.listeners.ngrok.tunnels inline_key=type"`
@@ -177,7 +177,7 @@ func (n *Ngrok) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		for nesting := d.Nesting(); d.NextBlock(nesting); {
 			subdirective := d.Val()
 			switch subdirective {
-			case "authtoken":
+			case "auth_token":
 				if !d.AllArgs(&n.AuthToken) {
 					n.AuthToken = ""
 				}

--- a/ngrok_test.go
+++ b/ngrok_test.go
@@ -51,7 +51,7 @@ func TestNgrokAuthToken(t *testing.T) {
 		{
 			name: "set authtoken",
 			caddyInput: `ngrok {
-				authtoken foo
+				auth_token foo
 			}`,
 			expectConfig: func(t *testing.T, actual *Ngrok) {
 				require.Equal(t, actual.AuthToken, "foo")
@@ -60,7 +60,7 @@ func TestNgrokAuthToken(t *testing.T) {
 		{
 			name: "authtoken-no-arg",
 			caddyInput: `ngrok {
-				authtoken
+				auth_token
 			}`,
 			expectConfig: func(t *testing.T, actual *Ngrok) {
 				require.Empty(t, actual.AuthToken)
@@ -69,7 +69,7 @@ func TestNgrokAuthToken(t *testing.T) {
 		{
 			name: "authtoken-too-many-arg",
 			caddyInput: `ngrok {
-				authtoken foo bar
+				auth_token foo bar
 			}`,
 			expectUnmarshalErr: true,
 		},
@@ -283,7 +283,7 @@ func TestNgrokTunnel(t *testing.T) {
 		{
 			name: "load labeled",
 			caddyInput: `ngrok {
-				authtoken test
+				auth_token test
 				tunnel labeled {
 					label foo bar
 				}


### PR DESCRIPTION
Currently the config in the readme does not work, since it was changed in [eda9c30](https://github.com/Zuruuh/caddy-ngrok-listener/commit/eda9c30f7dc2dd31a910ae4a73a61889103c2519), i struggled a bit when trying to use this code sample myself. Maybe it's worth considering reverting the changes until the underlying api changes ? Thanks! (Also, unrelated but this is a very cool project so congrats on pulling this off :clap:)